### PR TITLE
Typo on defaultValue

### DIFF
--- a/src/main/java/com/soebes/maven/plugins/doxygen/AbstractDoxygenMojo.java
+++ b/src/main/java/com/soebes/maven/plugins/doxygen/AbstractDoxygenMojo.java
@@ -60,7 +60,7 @@ public abstract class AbstractDoxygenMojo
 	 * 
 	 * @parameter expression="${doxygen.executable}" default-value="doxygen"
 	 */
-    @Parameter(property = "doxygen.executable", defaultValue = "doxgen")
+    @Parameter(property = "doxygen.executable", defaultValue = "doxygen")
 	private String executable;
 	
     /**


### PR DESCRIPTION
Typo on defaultValue : "doxgen" instead of "doxygen".
Thanks for your work.
Regards